### PR TITLE
Reduce enemy density and add animated enemy SVG

### DIFF
--- a/enemy.svg
+++ b/enemy.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <g>
+    <circle cx="50" cy="50" r="25" fill="#e74c3c">
+      <animate attributeName="r" values="20;25;20" dur="0.8s" repeatCount="indefinite" />
+    </circle>
+    <circle cx="40" cy="45" r="5" fill="#fff">
+      <animate attributeName="cy" values="45;40;45" dur="0.8s" repeatCount="indefinite" />
+    </circle>
+    <circle cx="60" cy="45" r="5" fill="#fff">
+      <animate attributeName="cy" values="45;40;45" dur="0.8s" repeatCount="indefinite" />
+    </circle>
+  </g>
+</svg>

--- a/script.js
+++ b/script.js
@@ -43,6 +43,10 @@ const ITEM_SIZE = 20;
 const ITEM_SPEED = 0.15;
 const MIN_OBSTACLE_GAP = 80;
 
+// 敵のSVG画像
+const enemyImage = new Image();
+enemyImage.src = 'enemy.svg';
+
 let lastObstacleSpawnTime = 0;
 let lastItemSpawnTime = 0;
 let lastDifficultyScore = -1;
@@ -280,15 +284,7 @@ function Obstacle(x, y, width, height, type = 'pillar') {
             ctx.lineWidth = 2;
             ctx.strokeRect(this.x, this.y, this.width, this.height);
         } else {
-            ctx.font = `${this.height}px serif`;
-            ctx.textBaseline = 'top';
-            const emojiMap = {
-                cloud: '☁️',
-                crow: '🐦‍⬛',
-                helicopter: '🚁',
-                ufo: '🛸'
-            };
-            ctx.fillText(emojiMap[this.type] || '⬛', this.x, this.y);
+            ctx.drawImage(enemyImage, this.x, this.y, this.width, this.height);
         }
     };
 
@@ -601,7 +597,8 @@ function spawnObstacle() {
     }
 
     const dynamicTypes = ['cloud', 'crow', 'helicopter', 'ufo'];
-    for (let i = 0; i < difficulty; i++) {
+    const enemyCount = Math.max(0, difficulty - 1);
+    for (let i = 0; i < enemyCount; i++) {
         const type = dynamicTypes[Math.floor(Math.random() * dynamicTypes.length)];
         const size = type === 'cloud' ? 40 : 30;
         const blockWidth = size;


### PR DESCRIPTION
## Summary
- Load and draw enemies from an animated SVG image
- Lower dynamic enemy count as score rises to avoid early collisions

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688c8b918c908330b78efcacfba26cd5